### PR TITLE
fix-consumption-by-block

### DIFF
--- a/custom_components/mojelektro/manifest.json
+++ b/custom_components/mojelektro/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/frlequ/homeassistant-mojelektro/issues",
   "requirements": ["requests>=2.25.1"],
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/custom_components/mojelektro/moj_elektro_api.py
+++ b/custom_components/mojelektro/moj_elektro_api.py
@@ -332,23 +332,24 @@ class MojElektroApi:
     def consumption_by_block(self, data, blocks):
         # Initialize variables to store summed values
         blocks_sums = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
-        
-        # If data is a list, use the first item as the source of readings
-        if isinstance(data, list):
-            data = data[0] if data else {}
 
-        # Verify if data has 'intervalReadings' directly
-        interval_readings = data.get("intervalReadings", [])
-        
-        for reading in interval_readings:
-            timestamp = reading["timestamp"]
-            value = float(reading["value"])
-            
-            # Determine the block based on timestamp
-            block_num = self.calculate_tariff(timestamp)
+        # Specify the readingType
+        reading_type = "32.0.2.4.1.2.12.0.0.0.0.0.0.0.0.3.72.0"
 
-            # Sum the value into the corresponding block
-            blocks_sums[block_num] += value
+        for block in data:
+            if block.get("readingType") == reading_type:
+                # Extract intervalReadings from the block
+                interval_readings = block.get("intervalReadings", [])
+                _LOGGER.debug(f"interval_readings: {interval_readings} ")
+                for reading in interval_readings:
+                    timestamp = reading["timestamp"]
+                    value = float(reading["value"])
+                    
+                    # Determine the block based on timestamp
+                    block_num = self.calculate_tariff(timestamp)
+
+                    # Sum the value into the corresponding block
+                    blocks_sums[block_num] += value
 
         # Map block sums to sensor names
         result = {}

--- a/custom_components/mojelektro/sensor.py
+++ b/custom_components/mojelektro/sensor.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
+import os
+import json
 
 from .const import DOMAIN, CONF_TOKEN, CONF_METER_ID, CONF_DECIMAL
 from .moj_elektro_api import MojElektroApi  # Ensure this matches the actual location and name
@@ -107,7 +109,7 @@ class MojElektroSensor(CoordinatorEntity, SensorEntity):
             "name": "Moj Elektro",
             "manufacturer": "Moj Elektro",
             "model": {self.meter_id},  # Include meter_id in the model
-            "sw_version": "0.2.5",
+            "sw_version": self.get_version(),
             "entry_type": DeviceEntryType.SERVICE,  # Use enum instead of string
         }
         _LOGGER.debug(f"Setting up device info {self.meter_id} .")
@@ -128,3 +130,10 @@ class MojElektroSensor(CoordinatorEntity, SensorEntity):
             return self._last_known_state
             
         return None
+
+    # Get the version from the manifest.json
+    def get_version(self):
+        manifest_path = os.path.join(os.path.dirname(__file__), 'manifest.json')
+        with open(manifest_path, 'r') as f:
+            manifest = json.load(f)
+        return manifest.get('version', 'Unknown')


### PR DESCRIPTION
## New Fixes
Users with multiple `intervalReadings` meters (mostly solar users) were not receiving correct consumption by block sensor updates. This was due to an incorrect or missing verification of the `readingType` value. 

Added additional checks to validate the `readingType` value is for energy input before returning sensor updates.